### PR TITLE
Update Tor makefile

### DIFF
--- a/tor/Makefile
+++ b/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.3.2.10
-PKG_RELEASE:=2
+PKG_VERSION:=0.4.2.5
+PKG_RELEASE:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=60df77c31dcf94fdd686c8ca8c34f3b70243b33a7344ecc0b719d5ca2617cbee
+PKG_HASH:=4d5975862e7808faebe9960def6235669fafeeac844cb76965501fa7af79d8c2
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
@@ -46,7 +46,7 @@ endef
 
 define Package/tor/description
 $(call Package/tor/Default/description)
- This package contains the tor daemon.
+ This package contains the Tor daemon.
 endef
 
 define Package/tor-gencert
@@ -68,7 +68,7 @@ endef
 
 define Package/tor-resolve/description
 $(call Package/tor/Default/description)
- Resolve a hostname to an IP address via tor 
+ Resolve a hostname to an IP address via Tor 
 endef
 
 define Package/tor-geoip


### PR DESCRIPTION
Update Tor version to 0.4.2.5 (0.3.x has been EOL since October 2018)
Minor spelling corrections